### PR TITLE
fix(webdav): settings page buttons fixed bottom + version 1.1.1

### DIFF
--- a/webdav-music/manifest.json
+++ b/webdav-music/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "webdav-music",
   "name": "WebDAV 音乐",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "连接 WebDAV 服务器，浏览和播放云端音乐文件。",
   "author": "Oneday5799",
   "icon": "icon.svg",


### PR DESCRIPTION
## Summary

- 修复设置页重置/保存按钮随内容滚动的问题，按钮固定在页面底部
- 版本号更新至 1.1.1

## Files Changed

- webdav-music/manifest.json — 版本号 1.1.0 → 1.1.1
- webdav-music/index.js — 设置页按钮 fixed bottom
- webdav-music/README.md — 更新日志