### PR TITLE
Add cover-color-lyric plugin (取色歌词)

### DIFF
--- a/echo-plugins.json
+++ b/echo-plugins.json
@@ -150,6 +150,21 @@
       ]
     },
     {
+      "id": "cover-color-lyric",
+      "name": "取色歌词",
+      "description": "桌面歌词颜色自动跟随歌曲封面主色调，算法与主程序 color.ts 完全一致；支持深浅色归一化、频谱律动、一键恢复默认设置",
+      "author": "小栀",
+      "path": "",
+      "repo": "https://github.com/rinnki-L/cover-color-lyric",
+      "homepage": "https://github.com/rinnki-L/cover-color-lyric",
+      "tags": [
+        "appearance",
+        "lyrics",
+        "lyric-effects",
+        "cover"
+      ]
+    },
+    {
       "id": "custom-icon",
       "name": "自定义图标",
       "description": "允许用户自定义托盘图标、窗口标题栏图标、任务栏图标、桌面快捷方式图标以及启动画面。",


### PR DESCRIPTION
## 新增插件：取色歌词（cover-color-lyric）

### 简介
为 EchoMusic 桌面歌词提供**封面取色**能力，让"已播放"歌词自动使用当前歌曲封面的主色调，与主程序 `src/renderer/utils/color.ts` 中的 `extractDominantColor` 算法完全一致。

### 主要特性
- **算法对齐**：18 桶（20°/桶）+ `lScore = max(0.15, 1 - |l-0.5|*1.2)` 加权，与主程序 `color.ts` 完全一致
- **深浅色归一化**：复用主程序 `normalizeAccent`（深色 S∈[0.45,0.85]/L∈[0.55,0.72]，浅色 S∈[0.55,0.9]/L∈[0.42,0.55]）
- **快速通道**：用户在主程序开了"主色随封面"时直接复用 `themeStore.coverColor`，与页面歌词"跟随封面取色"完全一致
- **实时响应**：监听 `<html class="dark">` 切换、`theme.coverColor`/`accentMode`/`isDark` 变化
- **频谱律动**：基于 `ctx.audio.spectrum`，可调节律动强度
- **平滑过渡**：颜色切换有 0-2000ms 可调的过渡动画
- **恢复默认**：设置面板提供"恢复默认设置"按钮（带确认对话框）

### 兼容性
- 要求 `echoMusicVersion >= 2.2.6-beta.20`
- 仅声明 `audioSpectrum` 能力

### 仓库
- 插件仓库：https://github.com/rinnki-L/cover-color-lyric
- 作者：小栀
- License：待补充（如果上游要求）

### 测试情况
已在 Windows 11 + EchoMusic 上验证：
- 切歌时颜色自动更新
- 深浅色切换时颜色重新归一化
- 设置面板开关/滑块均可正常持久化
- "恢复默认设置"工作正常
- 频谱律动有明显视觉反馈

### manifest.json 摘要
```json
{
  "id": "cover-color-lyric",
  "name": "取色歌词",
  "version": "1.0.0",
  "author": "小栀",
  "main": "index.js",
  "capabilities": { "audioSpectrum": true },
  "requires": { "echoMusicVersion": ">=2.2.6-beta.20" }
}
```

---

参考已有 `taskbar-lyric` / `Lyrics-bridge` 的 `path: ""` + 外部 `repo` 模式实现，无需在本仓库中存放插件文件本体。