### PR TITLE
custom-icon: v1.7.7 fix startup sound on refresh

### DIFF
--- a/custom-icon/index.js
+++ b/custom-icon/index.js
@@ -905,7 +905,7 @@ export async function activate(ctx) {
         showSplash(ctx, state.settings);
       }
     }
-    if (state.settings.splashAudioEnabled && state.settings.splashAudioPath) {
+    if (state.settings.splashAudioEnabled && state.settings.splashAudioPath && document.querySelector(".loading-view")) {
       playSplashAudio(ctx, state.settings);
     }
   }

--- a/custom-icon/manifest.json
+++ b/custom-icon/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "custom-icon",
   "name": "自定义图标",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "description": "自定义托盘图标、任务栏图标、桌面快捷方式图标、启动画面以及启动音效。",
   "author": "Oneday5799",
   "icon": "icon.svg",


### PR DESCRIPTION
## Summary
- Fix: clicking refresh plugins button no longer triggers startup sound

## Changes
- manifest.json: version 1.7.6 -> 1.7.7
- index.js: check for .loading-view before playing startup audio, only plays on actual app startup not plugin refresh