### PR TITLE
fix: 修复歌词选择窗候选标题重复显示歌手名

### DIFF
--- a/webdav-music/README.md
+++ b/webdav-music/README.md
@@ -88,6 +88,10 @@ EchoMusicPlugins/
 
 ## 更新日志
 
+### v1.3.5
+
+- 修复歌词选择窗中候选歌曲标题重复显示歌手名的问题：使用酷狗返回的 `SongName` 字段替代包含歌手前缀的 `FileName`
+
 ### v1.3.4
 
 - 提取 `fetchFolderCover` 辅助函数，消除 3 处封面检测重复代码

--- a/webdav-music/index.js
+++ b/webdav-music/index.js
@@ -1919,7 +1919,7 @@ export async function activate(ctx) {
                   seen.add(key);
                   candidates.push({
                     id: c.id, accesskey: c.accesskey,
-                    singer: match.SingerName || "", song: match.SongName || match.FileName || "",
+                    singer: match.SingerName || "", song: match.SongName || "",
                     score: c.score ?? 0, duration: c.duration ?? 0,
                     krctype: c.krctype ?? 0, contenttype: c.contenttype ?? 0,
                     product_from: c.product_from || "", language: c.language || "",

--- a/webdav-music/manifest.json
+++ b/webdav-music/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "webdav-music",
   "name": "WebDAV 音乐",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "连接 WebDAV 服务器，浏览和播放云端音乐文件。",
   "author": "Oneday5799",
   "icon": "icon.svg",


### PR DESCRIPTION
## Summary

- 修复歌词选择窗中候选歌曲标题重复显示歌手名的问题
- 使用酷狗返回的 SongName 字段替代包含歌手前缀的 FileName，避免 singer - song 拼接时歌手名出现两次

## Changes

- index.js:1922 — song 字段改为 match.SongName || ''
- 版本号 1.3.4 -> 1.3.5
- README 更新日志