### PR TITLE
feat: 歌单详情页封面同步 + 插件API优化 (v1.8.4)

### DIFF
--- a/custom-icon/README.md
+++ b/custom-icon/README.md
@@ -71,6 +71,14 @@
 
 ## 更新日志
 
+### 1.8.4
+
+- 新增歌单详情页封面同步：进入歌单详情页时自动替换顶部封面为自定义封面
+- 优化 DOM 查询方式：使用插件 API（`ctx.dom.query`/`ctx.dom.queryAll`）替代原生 `document.querySelector`
+- 移除冗余的 `deactivate` 导出，统一由 `ctx.dispose` 管理清理逻辑
+- 提取 `applyCoverToContainer` 辅助函数，封装歌单详情页封面应用逻辑
+- 歌单详情页封面同步支持路由切换时自动刷新
+
 ### 1.8.3
 
 - 优化代码结构，格式化 CSS 以提升可读性

--- a/custom-icon/index.js
+++ b/custom-icon/index.js
@@ -443,6 +443,13 @@ let pmObserverDispose = null;
 let pmWatchDispose = null;
 let originalPics = new Map();
 let pmCtx = null;
+let detailCoverInterval = null;
+let routeWatchDispose = null;
+
+const removeDetailCoverObserver = () => {
+  if (detailCoverInterval) { clearInterval(detailCoverInterval); detailCoverInterval = null; }
+  if (routeWatchDispose) { routeWatchDispose(); routeWatchDispose = null; }
+};
 
 const normalizePmSettings = (stored) => {
   const src = (stored && typeof stored === "object") || Array.isArray(stored) ? stored : {};
@@ -455,6 +462,63 @@ const normalizePmSettings = (stored) => {
       ? Object.fromEntries(Object.entries(src.customCovers).filter(([, v]) => v && typeof v === "object"))
       : {},
   };
+};
+
+const getCurrentPlaylistIdFromUrl = () => {
+  const hash = window.location.hash || "";
+  const match = hash.match(/playlist\/([^/?]+)/);
+  return match ? decodeURIComponent(match[1]) : "";
+};
+
+const findPlaylistIdByUrl = (urlId) => {
+  if (!urlId || !pmCtx) return "";
+  const store = pmCtx.stores.playlist;
+  const playlists = store?.userPlaylists || [];
+  for (const p of playlists) {
+    const ids = [p.id, p.listid, p.listCreateGid, p.globalCollectionId, p.listCreateListid]
+      .filter((v) => v !== undefined && v !== null && String(v) !== "")
+      .map(String);
+    if (ids.includes(urlId)) {
+      return String(p.listid || p.id || "");
+    }
+  }
+  return "";
+};
+
+const applyCoverToContainer = (container, covers) => {
+  const urlId = getCurrentPlaylistIdFromUrl();
+  if (!urlId) return;
+  const playlistId = findPlaylistIdByUrl(urlId);
+  if (!playlistId) return;
+  const cover = covers[playlistId];
+  if (!cover?.previewUrl) return;
+  const url = cover.previewUrl;
+  container.style.setProperty("background-image", `url("${url}")`, "important");
+  container.style.setProperty("background-size", "cover", "important");
+  container.style.setProperty("background-position", "center", "important");
+  container.style.setProperty("background-repeat", "no-repeat", "important");
+  const img = container.querySelector("img.cover-img");
+  if (img && img.getAttribute("src") !== url) {
+    img.setAttribute("src", url);
+  }
+};
+
+const patchDetailCoverDom = (covers) => {
+  const detailPage = pmCtx?.dom?.query(".playlist-detail-page");
+  if (!detailPage) return;
+  const firstContainer = detailPage.querySelector(".cover-container");
+  if (firstContainer) applyCoverToContainer(firstContainer, covers);
+};
+
+const setupDetailCoverObserver = (ctx, pmSettings) => {
+  removeDetailCoverObserver();
+  if (!pmSettings.enabled) return;
+  const covers = pmSettings.customCovers || {};
+  patchDetailCoverDom(covers);
+  detailCoverInterval = setInterval(() => { patchDetailCoverDom(covers); }, 200);
+  routeWatchDispose = ctx.router.afterEach(() => {
+    setTimeout(() => { patchDetailCoverDom(covers); }, 300);
+  });
 };
 
 const getPlaylistId = (playlist) => String(playlist.listid || playlist.id || "");
@@ -475,7 +539,7 @@ const applyHiddenPlaylists = (ctx, pmSettings) => {
     const hiddenSet = new Set(pmSettings.hiddenPlaylistIds);
     const pinnedIds = playlists.filter((p) => isPlaylistDefault(p) || isPlaylistLiked(p, likedId)).map(getPlaylistId);
     const allPinnedHidden = pinnedIds.length > 0 && pinnedIds.every((id) => hiddenSet.has(id));
-    document.querySelectorAll(".sidebar-library-item, .sidebar-rail-cover-btn").forEach((el) => {
+    (pmCtx?.dom?.queryAll(".sidebar-library-item, .sidebar-rail-cover-btn") || []).forEach((el) => {
       const span = el.querySelector("span");
       const name = span ? span.textContent.trim() : "";
       const matched = playlists.find((p) => hiddenSet.has(getPlaylistId(p)) && name === (p.name || ""));
@@ -484,7 +548,7 @@ const applyHiddenPlaylists = (ctx, pmSettings) => {
         el.setAttribute("data-playlist-id", getPlaylistId(matched));
       }
     });
-    document.querySelectorAll(".sidebar-playlist-divider").forEach((el) => {
+    (pmCtx?.dom?.queryAll(".sidebar-playlist-divider") || []).forEach((el) => {
       if (allPinnedHidden) {
         el.setAttribute("data-echo-hidden-divider", "true");
       } else {
@@ -502,11 +566,11 @@ const applyHiddenPlaylists = (ctx, pmSettings) => {
 const removeHiddenPlaylists = () => {
   if (pmCssDispose) { pmCssDispose(); pmCssDispose = null; }
   if (pmObserverDispose) { pmObserverDispose(); pmObserverDispose = null; }
-  document.querySelectorAll('[data-echo-hidden-playlist="true"]').forEach((el) => {
+  (pmCtx?.dom?.queryAll('[data-echo-hidden-playlist="true"]') || []).forEach((el) => {
     el.removeAttribute("data-echo-hidden-playlist");
     el.removeAttribute("data-playlist-id");
   });
-  document.querySelectorAll('[data-echo-hidden-divider="true"]').forEach((el) => {
+  (pmCtx?.dom?.queryAll('[data-echo-hidden-divider="true"]') || []).forEach((el) => {
     el.removeAttribute("data-echo-hidden-divider");
   });
 };
@@ -526,6 +590,7 @@ const removeCustomCovers = () => {
 
 const applyCustomCovers = async (ctx, pmSettings) => {
   removeCustomCovers();
+  removeDetailCoverObserver();
   if (!pmSettings.enabled) return;
   const store = ctx.stores.playlist;
   const playlists = store?.userPlaylists || [];
@@ -538,6 +603,7 @@ const applyCustomCovers = async (ctx, pmSettings) => {
       playlist.pic = cover.previewUrl;
     }
   }
+  setupDetailCoverObserver(ctx, pmSettings);
 };
 
 const buildSettingsFromDraft = (draft, overrides = {}) => ({
@@ -659,7 +725,7 @@ const stopSplashAudio = () => {
   }
 };
 
-const getLoadingView = () => document.querySelector(".loading-view");
+const getLoadingView = () => (pmCtx?.dom?.query(".loading-view") || document.querySelector(".loading-view"));
 
 const playSplashAudio = async (ctx, settings) => {
   stopSplashAudio();
@@ -870,6 +936,7 @@ const cleanup = () => {
   splashObserverDispose?.(); splashObserverDispose = null;
   removeHiddenPlaylists();
   removeCustomCovers();
+  removeDetailCoverObserver();
   pmWatchDispose?.(); pmWatchDispose = null;
   pmCtx = null;
   state = null;
@@ -1634,8 +1701,4 @@ export async function activate(ctx) {
   try { await ctx.appIcons.refresh(); } catch {}
 
   ctx.dispose(cleanup);
-}
-
-export function deactivate() {
-  cleanup();
 }

--- a/custom-icon/manifest.json
+++ b/custom-icon/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "custom-icon",
   "name": "自定义图标和封面",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "自定义托盘图标、任务栏图标、桌面快捷方式图标、启动画面、启动音效以及管理歌单封面。",
   "author": "Oneday5799",
   "icon": "icon.svg",


### PR DESCRIPTION
## 变更内容

### 新功能
- **歌单详情页封面同步**：进入歌单详情页时自动替换顶部封面为自定义封面，支持路由切换时自动刷新

### 优化
- 使用插件 API（ctx.dom.query/ctx.dom.queryAll）替代原生 document.querySelector/document.querySelectorAll
- 移除冗余的 deactivate 导出，统一由 ctx.dispose 管理清理逻辑
- 提取 pplyCoverToContainer 辅助函数，封装歌单详情页封面应用逻辑

### 修复
- 歌单详情页封面与侧边栏封面现在同步显示自定义封面
- URL ID（globalCollectionId）到歌单 listid 的正确映射