### PR TITLE
新增酷狗概念会员签到插件

### DIFF
--- a/echo-plugins.json
+++ b/echo-plugins.json
@@ -356,6 +356,17 @@
         "radio",
         "fm"
       ]
+    },
+    {
+      "id": "kugou-checkin",
+      "path": "kugou-checkin",
+      "repo": "https://github.com/rurucxk/echomusic-kugou-checkin-source",
+      "homepage": "https://github.com/rurucxk/echomusic-kugou-checkin-source",
+      "tags": [
+        "kugou",
+        "checkin",
+        "vip"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 说明

- 在官方 `echo-plugins.json` 中新增 `kugou-checkin` 索引。
- 插件由独立公开仓库发布，官方仓库无需复制插件源码。
- 插件用于自动完成酷狗概念会员听歌签到，支持定时、启动检查和手动触发。
- 插件基于 `liangshengmoran/kgCheckin` 的签到思路与接口调用方式改造。
- 插件代码由 GPT/Codex 生成，并由作者完成本地测试与实际运行验证。

## 插件仓库

https://github.com/rurucxk/echomusic-kugou-checkin-source

## 验证

- `manifest.json` 版本：`1.0.2`
- 索引 `id` 与 manifest `id` 均为 `kugou-checkin`
- `path` 指向 `kugou-checkin`，目录内包含有效的 `manifest.json`